### PR TITLE
Use LaTeX for PR metrics.

### DIFF
--- a/pull_requests.go
+++ b/pull_requests.go
@@ -115,7 +115,7 @@ func (p *PullRequest) GetPRMetrics() (template.HTML, error) {
 		return "", fmt.Errorf("PR information not updated")
 	}
 
-	format := `<span style="color:#3fb950">+%s</span> <span style="color:#f85149">-%s</span>`
+	format := `$\textcolor{green}{%s}$ $\textcolor{red}{%s}$`
 	return template.HTML(fmt.Sprintf(format, formatNumber(p.Additions), formatNumber(p.Deletions))), nil
 }
 


### PR DESCRIPTION
It seems GitHub markdown doesn't support font color inline.